### PR TITLE
Bug Fix for using pretrained models for checkpointing 

### DIFF
--- a/nsm/computer_factory.py
+++ b/nsm/computer_factory.py
@@ -316,8 +316,8 @@ class LispInterpreter(object):
     mem_tokens = []
     for i in range(self.max_mem):
       mem_tokens.append('v{}'.format(i))
-      vocab = data_utils.Vocab(
-        self.namespace.get_all_names() + SPECIAL_TKS + mem_tokens)
+    vocab = data_utils.Vocab(
+      self.namespace.get_all_names() + SPECIAL_TKS + mem_tokens)
     return vocab
 
 

--- a/nsm/computer_factory.py
+++ b/nsm/computer_factory.py
@@ -1,5 +1,6 @@
 """Computers can read in tokens, parse them into a program, and execute it."""
 
+from collections import OrderedDict
 import re
 import copy
 import sys
@@ -321,7 +322,7 @@ class LispInterpreter(object):
     return vocab
 
 
-class Namespace(dict):
+class Namespace(OrderedDict):
   """Namespace is a mapping from names to values.
 
   Namespace maintains the mapping from names to their
@@ -331,12 +332,10 @@ class Namespace(dict):
   example, find all the functions or find all the entity
   lists).
   """
-  def __init__(self, name_value_dict=None):
+  def __init__(self, *args, **kwargs):
     """Initialize the namespace with a list of functions."""
     # params = dict(zip(names, objs))
-    if name_value_dict == None:
-      name_value_dict = {}
-    dict.__init__(self, **name_value_dict)
+    super(Namespace, self).__init__(*args, **kwargs)
     self.n_var = 0
     self.last_var = None
 


### PR DESCRIPTION
If the ordering across namespace dict is not consistent across multiple runs (may or may not use the same machine) of the same model, using a pre-trained model to initialize your model would fail. The ordering was inconsistent due to `get_all_names` function would return a non deterministic ordering across different runs which would change the mapping in `de_vocab`. Different ordering of `de_vocab` would make lead to different/wrong results at inference time.